### PR TITLE
Added missing link in godan_api_ui

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,7 @@ godan_api_ui:
     - "8000:8000"
   links:
     - ui_db:ui_db
+    - godan_server:godan_server
 godan_web_ui:
   build: ./ui/webui/
   ports:


### PR DESCRIPTION
Somehow a link was missing in the previous PR regarding docker-compose. Sorry about that!
